### PR TITLE
Fix profile loading and onboarding improvements

### DIFF
--- a/src/components/Job/JobCard.jsx
+++ b/src/components/Job/JobCard.jsx
@@ -86,10 +86,9 @@ const JobCard = ({ job }) => {
         <div className="mt-2">
           <button
             onClick={viewJobDetails}
-            className={`text-sm px-4 py-1 border rounded-md ml-auto block cursor-pointer
-              ${job?.applied ? "bg-gray-400 text-white cursor-not-allowed" : "bg-black text-white"}
+            className={`text-sm px-4 py-1 border rounded-md ml-auto block
+              ${job?.applied ? "bg-gray-400 text-white" : "bg-black text-white"}
             `}
-            disabled={job?.applied}
           >
             {job?.applied ? "Applied" : "View Details"}
           </button>

--- a/src/components/admin/Dashboard.jsx
+++ b/src/components/admin/Dashboard.jsx
@@ -22,7 +22,7 @@ const fetchDashboard = async () => {
     const recent = res?.data?.recentActivity || [];
 
     setDashboard({ metrics, recentActivity: recent });
-  } catch (err) {
+  } catch {
     toast.error("Failed to fetch dashboard");
   }
 };

--- a/src/components/calendar/MyFullCalendar.jsx
+++ b/src/components/calendar/MyFullCalendar.jsx
@@ -5,7 +5,7 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import EventDetailsModal from "./EventDetailsModal";
-import { format, parseISO } from "date-fns";
+import { format } from "date-fns";
 import { toast } from "react-toastify";
 
 export default function MyFullCalendar() {

--- a/src/components/jobApplicants/ApplicantDetails.jsx
+++ b/src/components/jobApplicants/ApplicantDetails.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { getStudentProfile } from "@/api/student";
+import { fetchApplicant } from "@/api/school";
+import { useParams } from "react-router-dom";
 import profileImg from "../../assets/image1.png";
 import { Mail } from "lucide-react";
 
@@ -8,13 +10,23 @@ const ApplicantDetails = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [openIndex, setOpenIndex] = useState(null);
+  const { applicantId } = useParams();
 
   const toggleSkill = (idx) => setOpenIndex(openIndex === idx ? null : idx);
 
   const fetchStudent = async () => {
     try {
-      const res = await getStudentProfile();
-      setProfile(res);
+      if (applicantId) {
+        const res = await fetchApplicant(applicantId);
+        if (res.success) {
+          setProfile(res.data.profile);
+        } else {
+          setError(res.message || "Failed to fetch profile");
+        }
+      } else {
+        const res = await getStudentProfile();
+        setProfile(res);
+      }
     } catch (err) {
       setError(err.message);
     } finally {

--- a/src/components/onboarding/Onboarding.jsx
+++ b/src/components/onboarding/Onboarding.jsx
@@ -5,35 +5,52 @@ import { toast } from "react-toastify";
 
 const Onboarding = () => {
   const navigate = useNavigate();
-  const [formData, setFormData] = useState({
-    firstName: "",
-    lastName: "",
-    mobile: "",
-    about: "",
-    skills: [],
-    education: [
-      {
-        college_name: "",
-        university_name: "",
-        course_name: "",
-        start_year: "",
-        end_year: "",
-        gpa: "",
-      },
-    ],
-    certifications: [
-      {
-        name: "",
-        issued_by: "",
-        description: "",
-        date_received: "",
-        has_expiry: false,
-        expiry_date: "",
-        certificate_link: "",
-      },
-    ],
-    image: null,
-  });
+  const user = JSON.parse(localStorage.getItem("user"));
+  const isSchool = user?.role === "school";
+
+  const [formData, setFormData] = useState(
+    isSchool
+      ? {
+          bio: "",
+          website_link: "",
+          address: {
+            address: "",
+            city: "",
+            state: "",
+            pincode: "",
+          },
+          image: null,
+        }
+      : {
+          firstName: "",
+          lastName: "",
+          mobile: "",
+          about: "",
+          skills: [],
+          education: [
+            {
+              college_name: "",
+              university_name: "",
+              course_name: "",
+              start_year: "",
+              end_year: "",
+              gpa: "",
+            },
+          ],
+          certifications: [
+            {
+              name: "",
+              issued_by: "",
+              description: "",
+              date_received: "",
+              has_expiry: false,
+              expiry_date: "",
+              certificate_link: "",
+            },
+          ],
+          image: null,
+        }
+  );
 
   useEffect(() => {
     const user = JSON.parse(localStorage.getItem("user"));
@@ -44,26 +61,32 @@ const Onboarding = () => {
 
   const handleChange = (e) => {
     const { name, value, files, type, checked } = e.target;
-if (name === "image") {
-  const file = files[0];
-  if (file && file.size > 1024 * 1024) {
-    toast.error("Image must be less than 1MB.");
-    return;
-  }
-  setFormData({ ...formData, image: file });
-}
- else if (name.startsWith("education")) {
-      const [_, index, field] = name.split(".");
+
+    if (name === "image") {
+      const file = files[0];
+      if (file && file.size > 1024 * 1024) {
+        toast.error("Image must be less than 1MB.");
+        return;
+      }
+      setFormData({ ...formData, image: file });
+    } else if (!isSchool && name.startsWith("education")) {
+      const [, index, field] = name.split(".");
       const updated = [...formData.education];
       updated[index][field] = value;
       setFormData({ ...formData, education: updated });
-    } else if (name.startsWith("certifications")) {
-      const [_, index, field] = name.split(".");
+    } else if (!isSchool && name.startsWith("certifications")) {
+      const [, index, field] = name.split(".");
       const updated = [...formData.certifications];
       updated[index][field] = type === "checkbox" ? checked : value;
       setFormData({ ...formData, certifications: updated });
+    } else if (isSchool && name.startsWith("address.")) {
+      const field = name.split(".")[1];
+      setFormData({
+        ...formData,
+        address: { ...formData.address, [field]: value },
+      });
     } else {
-      setFormData({ ...formData, [name]: value });
+      setFormData({ ...formData, [name]: type === "checkbox" ? checked : value });
     }
   };
 
@@ -93,34 +116,46 @@ const handleSubmit = async (e) => {
   if (!user) return toast.error("User not found!");
 
   try {
-    const profile = {
-      firstName: formData.firstName?.trim(),
-      lastName: formData.lastName?.trim(),
-      mobile: formData.mobile?.trim(),
-      about: formData.about?.trim(),
-      skills: formData.skills.filter(Boolean),
-      education: formData.education.map(e => ({
-        college_name: e.college_name?.trim(),
-        university_name: e.university_name?.trim(),
-        course_name: e.course_name?.trim(),
-        start_year: Number(e.start_year),
-        end_year: Number(e.end_year),
-        gpa: e.gpa?.trim(),
-      })),
-certifications: formData.certifications.map(c => ({
-  name: c.name?.trim(),
-  issued_by: c.issued_by?.trim(),
-  description: c.description?.trim(),
-  date_received: c.date_received,
-  has_expiry: c.has_expiry,
-  expiry_date: c.has_expiry ? c.expiry_date : null,
-  ...(c.certificate_link?.trim() && { certificate_link: c.certificate_link?.trim() })
-})),
-
-    };
+    const profile = isSchool
+      ? {
+          bio: formData.bio?.trim(),
+          website_link: formData.website_link?.trim(),
+          address: {
+            address: formData.address.address?.trim(),
+            city: formData.address.city?.trim(),
+            state: formData.address.state?.trim(),
+            pincode: formData.address.pincode?.trim(),
+          },
+        }
+      : {
+          firstName: formData.firstName?.trim(),
+          lastName: formData.lastName?.trim(),
+          mobile: formData.mobile?.trim(),
+          about: formData.about?.trim(),
+          skills: formData.skills.filter(Boolean),
+          education: formData.education.map((e) => ({
+            college_name: e.college_name?.trim(),
+            university_name: e.university_name?.trim(),
+            course_name: e.course_name?.trim(),
+            start_year: Number(e.start_year),
+            end_year: Number(e.end_year),
+            gpa: e.gpa?.trim(),
+          })),
+          certifications: formData.certifications.map((c) => ({
+            name: c.name?.trim(),
+            issued_by: c.issued_by?.trim(),
+            description: c.description?.trim(),
+            date_received: c.date_received,
+            has_expiry: c.has_expiry,
+            expiry_date: c.has_expiry ? c.expiry_date : null,
+            ...(c.certificate_link?.trim() && {
+              certificate_link: c.certificate_link?.trim(),
+            }),
+          })),
+        };
 
     const payload = new FormData();
-    payload.append("role", "student");
+    payload.append("role", isSchool ? "school" : "student");
     payload.append("profileData", JSON.stringify(profile));
     if (formData.image) payload.append("image", formData.image);
 
@@ -144,60 +179,251 @@ certifications: formData.certifications.map(c => ({
 
   return (
     <div className="max-w-3xl mx-auto mt-8 p-6 border shadow rounded">
-      <h2 className="text-2xl font-bold mb-6">Student Onboarding</h2>
+      <h2 className="text-2xl font-bold mb-6">
+        {isSchool ? "School Onboarding" : "Student Onboarding"}
+      </h2>
       <form onSubmit={handleSubmit} className="space-y-5">
-
-        <div className="grid grid-cols-2 gap-4">
-          <input name="firstName" value={formData.firstName} onChange={handleChange} placeholder="First Name" className="border p-2 rounded" required />
-          <input name="lastName" value={formData.lastName} onChange={handleChange} placeholder="Last Name" className="border p-2 rounded" required />
-        </div>
-
-        <input name="mobile" value={formData.mobile} onChange={handleChange} placeholder="Mobile" className="w-full border p-2 rounded" required />
-        <textarea name="about" value={formData.about} onChange={handleChange} placeholder="About yourself" rows={3} className="w-full border p-2 rounded" required />
-        
-        <input name="skills" onChange={handleSkillChange} placeholder="Skills (comma-separated)" className="w-full border p-2 rounded" />
-
-        <div>
-          <h3 className="font-semibold">Education</h3>
-          {formData.education.map((edu, index) => (
-            <div key={index} className="grid grid-cols-2 gap-4 my-2">
-              <input name={`education.${index}.college_name`} placeholder="College Name" value={edu.college_name} onChange={handleChange} className="border p-2 rounded" />
-              <input name={`education.${index}.university_name`} placeholder="University Name" value={edu.university_name} onChange={handleChange} className="border p-2 rounded" />
-              <input name={`education.${index}.course_name`} placeholder="Course" value={edu.course_name} onChange={handleChange} className="border p-2 rounded" />
-              <input name={`education.${index}.gpa`} placeholder="GPA" value={edu.gpa} onChange={handleChange} className="border p-2 rounded" />
-              <input name={`education.${index}.start_year`} placeholder="Start Year" value={edu.start_year} onChange={handleChange} className="border p-2 rounded" />
-              <input name={`education.${index}.end_year`} placeholder="End Year" value={edu.end_year} onChange={handleChange} className="border p-2 rounded" />
+        {isSchool ? (
+          <>
+            <textarea
+              name="bio"
+              value={formData.bio}
+              onChange={handleChange}
+              placeholder="Bio"
+              className="w-full border p-2 rounded"
+              required
+            />
+            <input
+              name="website_link"
+              value={formData.website_link}
+              onChange={handleChange}
+              placeholder="Website Link"
+              className="w-full border p-2 rounded"
+              required
+            />
+            <div className="grid grid-cols-2 gap-4">
+              <input
+                name="address.address"
+                value={formData.address.address}
+                onChange={handleChange}
+                placeholder="Address"
+                className="border p-2 rounded"
+                required
+              />
+              <input
+                name="address.city"
+                value={formData.address.city}
+                onChange={handleChange}
+                placeholder="City"
+                className="border p-2 rounded"
+                required
+              />
+              <input
+                name="address.state"
+                value={formData.address.state}
+                onChange={handleChange}
+                placeholder="State"
+                className="border p-2 rounded"
+                required
+              />
+              <input
+                name="address.pincode"
+                value={formData.address.pincode}
+                onChange={handleChange}
+                placeholder="Pincode"
+                className="border p-2 rounded"
+                required
+              />
             </div>
-          ))}
-          <button type="button" onClick={addEducation} className="text-blue-600 text-sm mt-1">+ Add Education</button>
-        </div>
-
-        <div>
-          <h3 className="font-semibold">Certifications</h3>
-          {formData.certifications.map((cert, index) => (
-            <div key={index} className="space-y-2 my-2">
-              <input name={`certifications.${index}.name`} placeholder="Certificate Name" value={cert.name} onChange={handleChange} className="border p-2 rounded w-full" />
-              <input name={`certifications.${index}.issued_by`} placeholder="Issued By" value={cert.issued_by} onChange={handleChange} className="border p-2 rounded w-full" />
-              <input name={`certifications.${index}.description`} placeholder="Description" value={cert.description} onChange={handleChange} className="border p-2 rounded w-full" />
-              <input name={`certifications.${index}.date_received`} type="date" value={cert.date_received} onChange={handleChange} className="border p-2 rounded w-full" />
-              <label>
-                <input type="checkbox" name={`certifications.${index}.has_expiry`} checked={cert.has_expiry} onChange={handleChange} /> Has Expiry
-              </label>
-              {cert.has_expiry && (
-                <input name={`certifications.${index}.expiry_date`} type="date" value={cert.expiry_date} onChange={handleChange} className="border p-2 rounded w-full" />
-              )}
-              <input name={`certifications.${index}.certificate_link`} placeholder="Certificate Link" value={cert.certificate_link} onChange={handleChange} className="border p-2 rounded w-full" />
+          </>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4">
+              <input
+                name="firstName"
+                value={formData.firstName}
+                onChange={handleChange}
+                placeholder="First Name"
+                className="border p-2 rounded"
+                required
+              />
+              <input
+                name="lastName"
+                value={formData.lastName}
+                onChange={handleChange}
+                placeholder="Last Name"
+                className="border p-2 rounded"
+                required
+              />
             </div>
-          ))}
-          <button type="button" onClick={addCertification} className="text-blue-600 text-sm">+ Add Certification</button>
-        </div>
+
+            <input
+              name="mobile"
+              value={formData.mobile}
+              onChange={handleChange}
+              placeholder="Mobile"
+              className="w-full border p-2 rounded"
+              required
+            />
+            <textarea
+              name="about"
+              value={formData.about}
+              onChange={handleChange}
+              placeholder="About yourself"
+              rows={3}
+              className="w-full border p-2 rounded"
+              required
+            />
+
+            <input
+              name="skills"
+              onChange={handleSkillChange}
+              placeholder="Skills (comma-separated)"
+              className="w-full border p-2 rounded"
+            />
+
+            <div>
+              <h3 className="font-semibold">Education</h3>
+              {formData.education.map((edu, index) => (
+                <div key={index} className="grid grid-cols-2 gap-4 my-2">
+                  <input
+                    name={`education.${index}.college_name`}
+                    placeholder="College Name"
+                    value={edu.college_name}
+                    onChange={handleChange}
+                    className="border p-2 rounded"
+                  />
+                  <input
+                    name={`education.${index}.university_name`}
+                    placeholder="University Name"
+                    value={edu.university_name}
+                    onChange={handleChange}
+                    className="border p-2 rounded"
+                  />
+                  <input
+                    name={`education.${index}.course_name`}
+                    placeholder="Course"
+                    value={edu.course_name}
+                    onChange={handleChange}
+                    className="border p-2 rounded"
+                  />
+                  <input
+                    name={`education.${index}.gpa`}
+                    placeholder="GPA"
+                    value={edu.gpa}
+                    onChange={handleChange}
+                    className="border p-2 rounded"
+                  />
+                  <input
+                    name={`education.${index}.start_year`}
+                    placeholder="Start Year"
+                    value={edu.start_year}
+                    onChange={handleChange}
+                    className="border p-2 rounded"
+                  />
+                  <input
+                    name={`education.${index}.end_year`}
+                    placeholder="End Year"
+                    value={edu.end_year}
+                    onChange={handleChange}
+                    className="border p-2 rounded"
+                  />
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={addEducation}
+                className="text-blue-600 text-sm mt-1"
+              >
+                + Add Education
+              </button>
+            </div>
+
+            <div>
+              <h3 className="font-semibold">Certifications</h3>
+              {formData.certifications.map((cert, index) => (
+                <div key={index} className="space-y-2 my-2">
+                  <input
+                    name={`certifications.${index}.name`}
+                    placeholder="Certificate Name"
+                    value={cert.name}
+                    onChange={handleChange}
+                    className="border p-2 rounded w-full"
+                  />
+                  <input
+                    name={`certifications.${index}.issued_by`}
+                    placeholder="Issued By"
+                    value={cert.issued_by}
+                    onChange={handleChange}
+                    className="border p-2 rounded w-full"
+                  />
+                  <input
+                    name={`certifications.${index}.description`}
+                    placeholder="Description"
+                    value={cert.description}
+                    onChange={handleChange}
+                    className="border p-2 rounded w-full"
+                  />
+                  <input
+                    name={`certifications.${index}.date_received`}
+                    type="date"
+                    value={cert.date_received}
+                    onChange={handleChange}
+                    className="border p-2 rounded w-full"
+                  />
+                  <label>
+                    <input
+                      type="checkbox"
+                      name={`certifications.${index}.has_expiry`}
+                      checked={cert.has_expiry}
+                      onChange={handleChange}
+                    />
+                    Has Expiry
+                  </label>
+                  {cert.has_expiry && (
+                    <input
+                      name={`certifications.${index}.expiry_date`}
+                      type="date"
+                      value={cert.expiry_date}
+                      onChange={handleChange}
+                      className="border p-2 rounded w-full"
+                    />
+                  )}
+                  <input
+                    name={`certifications.${index}.certificate_link`}
+                    placeholder="Certificate Link"
+                    value={cert.certificate_link}
+                    onChange={handleChange}
+                    className="border p-2 rounded w-full"
+                  />
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={addCertification}
+                className="text-blue-600 text-sm"
+              >
+                + Add Certification
+              </button>
+            </div>
+          </>
+        )}
 
         <div>
           <label>Upload Image</label>
-          <input type="file" name="image" accept="image/*" onChange={handleChange} className="w-full border p-2 rounded" />
+          <input
+            type="file"
+            name="image"
+            accept="image/*"
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+          />
         </div>
 
-        <button type="submit" className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
+        <button
+          type="submit"
+          className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700"
+        >
           Submit
         </button>
       </form>

--- a/src/components/student/StudentProfileUpdate.jsx
+++ b/src/components/student/StudentProfileUpdate.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { updateStudentProfile } from "@/api/student";
+import React, { useEffect, useState } from "react";
+import { updateStudentProfile, getStudentProfile } from "@/api/student";
 import { toast } from "react-toastify";
 
 export default function StudentProfileUpdate() {
@@ -35,18 +35,69 @@ export default function StudentProfileUpdate() {
     image: null,
   });
 
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        const res = await getStudentProfile();
+        if (res) {
+          setFormData({
+            firstName: res.firstName || "",
+            lastName: res.lastName || "",
+            mobile: res.mobile || "",
+            about: res.about || "",
+            skills: res.skills || [],
+            education:
+              Array.isArray(res.education) && res.education.length > 0
+                ? res.education
+                : [
+                    {
+                      collegeName: "",
+                      universityName: "",
+                      courseName: "",
+                      startYear: "",
+                      endYear: "",
+                      gpa: "",
+                    },
+                  ],
+            certifications:
+              Array.isArray(res.certifications) && res.certifications.length > 0
+                ? res.certifications
+                : [
+                    {
+                      name: "",
+                      issuedBy: "",
+                      description: "",
+                      dateReceived: "",
+                      hasExpiry: false,
+                      expiryDate: "",
+                      certificateLink: "",
+                    },
+                  ],
+            image: null,
+          });
+        }
+      } catch {
+        toast.error("Failed to load profile");
+      }
+    };
+    loadProfile();
+  }, []);
+
   const handleChange = (e) => {
     const { name, value, files, type, checked } = e.target;
-if (name === "image") {
-  const file = files[0];
-  if (file && file.size > 1024 * 1024) {
-    toast.error("Image must be less than 1MB.");
-    return;
-  }
-  setFormData({ ...formData, image: file });
-}
- else {
-      setFormData({ ...formData, [name]: type === "checkbox" ? checked : value });
+
+    if (name === "image") {
+      const file = files[0];
+      if (file && file.size > 1024 * 1024) {
+        toast.error("Image must be less than 1MB.");
+        return;
+      }
+      setFormData({ ...formData, image: file });
+    } else {
+      setFormData({
+        ...formData,
+        [name]: type === "checkbox" ? checked : value,
+      });
     }
   };
 
@@ -93,6 +144,13 @@ if (name === "image") {
     });
   };
 
+  const removeEducation = (index) => {
+    setFormData({
+      ...formData,
+      education: formData.education.filter((_, i) => i !== index),
+    });
+  };
+
   const handleCertificationChange = (index, e) => {
     const updated = [...formData.certifications];
     const { name, type, value, checked } = e.target;
@@ -115,6 +173,13 @@ if (name === "image") {
           certificateLink: "",
         },
       ],
+    });
+  };
+
+  const removeCertification = (index) => {
+    setFormData({
+      ...formData,
+      certifications: formData.certifications.filter((_, i) => i !== index),
     });
   };
 
@@ -155,8 +220,22 @@ if (name === "image") {
       <form onSubmit={handleSubmit} className="space-y-4">
 
         <div className="grid grid-cols-2 gap-4">
-          <input type="text" name="firstName" placeholder="First Name" value={formData.firstName} onChange={handleChange} className="border p-2 rounded" required />
-          <input type="text" name="lastName" placeholder="Last Name" value={formData.lastName} onChange={handleChange} className="border p-2 rounded" required />
+          <input
+            type="text"
+            name="firstName"
+            placeholder="First Name"
+            value={formData.firstName}
+            disabled
+            className="border p-2 rounded bg-gray-100 cursor-not-allowed"
+          />
+          <input
+            type="text"
+            name="lastName"
+            placeholder="Last Name"
+            value={formData.lastName}
+            disabled
+            className="border p-2 rounded bg-gray-100 cursor-not-allowed"
+          />
         </div>
 
         <input type="tel" name="mobile" placeholder="Mobile" value={formData.mobile} onChange={handleChange} className="w-full border p-2 rounded" required />
@@ -180,13 +259,20 @@ if (name === "image") {
         <div>
           <label className="block font-medium mb-2">Education</label>
           {formData.education.map((edu, idx) => (
-            <div key={idx} className="grid grid-cols-2 gap-4 mb-4">
+            <div key={idx} className="grid grid-cols-2 gap-4 mb-4 relative">
               <input name="collegeName" value={edu.collegeName || ""} placeholder="College Name" onChange={(e) => handleEducationChange(idx, e)} className="border p-2 rounded" />
               <input name="universityName" value={edu.universityName || ""} placeholder="University Name" onChange={(e) => handleEducationChange(idx, e)} className="border p-2 rounded" />
               <input name="courseName" value={edu.courseName || ""} placeholder="Course Name" onChange={(e) => handleEducationChange(idx, e)} className="border p-2 rounded" />
               <input name="gpa" value={edu.gpa || ""} placeholder="GPA (optional)" onChange={(e) => handleEducationChange(idx, e)} className="border p-2 rounded" />
               <input name="startYear" value={edu.startYear || ""} placeholder="Start Year" onChange={(e) => handleEducationChange(idx, e)} className="border p-2 rounded" />
               <input name="endYear" value={edu.endYear || ""} placeholder="End Year" onChange={(e) => handleEducationChange(idx, e)} className="border p-2 rounded" />
+              <button
+                type="button"
+                onClick={() => removeEducation(idx)}
+                className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 text-xs"
+              >
+                ×
+              </button>
             </div>
           ))}
           <button type="button" onClick={addEducation} className="text-blue-600 text-sm">+ Add another education</button>
@@ -196,7 +282,7 @@ if (name === "image") {
         <div>
           <label className="block font-medium mb-2">Certifications</label>
           {formData.certifications.map((cert, idx) => (
-            <div key={idx} className="grid grid-cols-2 gap-4 mb-4">
+            <div key={idx} className="grid grid-cols-2 gap-4 mb-4 relative">
               <input name="name" value={cert.name || ""} placeholder="Certificate Name" onChange={(e) => handleCertificationChange(idx, e)} className="border p-2 rounded" />
               <input name="issuedBy" value={cert.issuedBy || ""} placeholder="Issued By" onChange={(e) => handleCertificationChange(idx, e)} className="border p-2 rounded" />
               <input name="description" value={cert.description || ""} placeholder="Description" onChange={(e) => handleCertificationChange(idx, e)} className="border p-2 rounded col-span-2" />
@@ -212,6 +298,13 @@ if (name === "image") {
               )}
 
               <input name="certificateLink" value={cert.certificateLink || ""} placeholder="Certificate Link" onChange={(e) => handleCertificationChange(idx, e)} className="border p-2 rounded col-span-2" />
+              <button
+                type="button"
+                onClick={() => removeCertification(idx)}
+                className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 text-xs"
+              >
+                ×
+              </button>
             </div>
           ))}
           <button type="button" onClick={addCertification} className="text-blue-600 text-sm">+ Add another certificate</button>

--- a/src/schoolProfile/SchoolProfile.jsx
+++ b/src/schoolProfile/SchoolProfile.jsx
@@ -15,7 +15,7 @@ const SchoolProfile = () => {
         } else {
           toast.error(res.message || "Failed to load profile");
         }
-      } catch (err) {
+      } catch {
         toast.error("An error occurred while fetching profile.");
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary
- keep job details button clickable after applying
- preload student profile on update page and allow removing entries
- fetch applicant details with correct API
- support school onboarding fields and validations
- minor lint fixes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68853a3cfe088331bc9e8caf913f0887