### PR TITLE
Fix applicant details link and student job card

### DIFF
--- a/src/components/Job/JobCard.jsx
+++ b/src/components/Job/JobCard.jsx
@@ -84,18 +84,15 @@ const JobCard = ({ job }) => {
         </p>
 
         <div className="mt-2 flex items-center gap-2">
+          {user?.role === "student" && job?.applied && (
+            <span className="text-xs text-green-600 font-medium">✅ Applied</span>
+          )}
           <button
             onClick={viewJobDetails}
-            className={`text-sm px-4 py-1 border rounded-md ml-auto block
-              ${job?.applied ? "bg-gray-400 text-white cursor-not-allowed" : "bg-black text-white"}
-            `}
-            disabled={!!job?.applied}
+            className="text-sm px-4 py-1 border rounded-md ml-auto block bg-black text-white"
           >
             View Details
           </button>
-          {job?.applied && (
-            <span className="text-xs text-green-600 font-medium">✅ Applied</span>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/applicationBoard/ApplicationsBoard_School.jsx
+++ b/src/components/applicationBoard/ApplicationsBoard_School.jsx
@@ -90,7 +90,7 @@ const ApplicationsBoard = () => {
 
                   <div className="flex justify-end">
                     <Link
-                      to={`/school/applicantDetails/${app?.applicantUserId}`}
+                      to={`/school/applicantDetails/${app?.id}`}
                       state={{ id: app?.id, status: app?.status }}
                       className="text-sm bg-gray-100 rounded p-2 hover:bg-gray-200"
                     >


### PR DESCRIPTION
## Summary
- pass applicationId when navigating to applicant details
- keep View Details active for students and show applied status

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68854fc843508331b084840ff38e7ad3