### PR TITLE
Fix applicant details link and student job card

### DIFF
--- a/src/components/Job/JobCard.jsx
+++ b/src/components/Job/JobCard.jsx
@@ -84,18 +84,15 @@ const JobCard = ({ job }) => {
         </p>
 
         <div className="mt-2 flex items-center gap-2">
+          {user?.role === "student" && job?.applied && (
+            <span className="text-xs text-green-600 font-medium">✅ Applied</span>
+          )}
           <button
             onClick={viewJobDetails}
-            className={`text-sm px-4 py-1 border rounded-md ml-auto block
-              ${job?.applied ? "bg-gray-400 text-white cursor-not-allowed" : "bg-black text-white"}
-            `}
-            disabled={!!job?.applied}
+            className="text-sm px-4 py-1 border rounded-md ml-auto block bg-black text-white"
           >
             View Details
           </button>
-          {job?.applied && (
-            <span className="text-xs text-green-600 font-medium">✅ Applied</span>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/applicationBoard/ApplicationsBoard_School.jsx
+++ b/src/components/applicationBoard/ApplicationsBoard_School.jsx
@@ -91,7 +91,7 @@ const ApplicationsBoard = () => {
                   <div className="flex justify-end">
                     <Link
                       to={`/school/applicantDetails/${app?.applicantUserId}`}
-                      state={{ id: app?.id, status: app?.status }}
+                      state={{ applicationId: app?.id, status: app?.status }}
                       className="text-sm bg-gray-100 rounded p-2 hover:bg-gray-200"
                     >
                       View Details

--- a/src/components/jobApplicants/ApplicantDetails.jsx
+++ b/src/components/jobApplicants/ApplicantDetails.jsx
@@ -15,7 +15,7 @@ const ApplicantDetails = () => {
   const [showSchedule, setShowSchedule] = useState(false);
   const { applicantId } = useParams();
   const location = useLocation();
-  const applicationId = location.state?.id;
+  const applicationId = location.state?.applicationId;
   const initialStatus = location.state?.status;
   const [isShortlisted, setIsShortlisted] = useState(
     initialStatus && initialStatus !== "New Candidates"


### PR DESCRIPTION
## Summary
- pass applicationId in router state when navigating from ApplicationsBoard
- keep View Details active for students with applied status badge

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68854fc843508331b084840ff38e7ad3