### PR TITLE
Fix applicant shortlisting ID retrieval

### DIFF
--- a/src/api/school.js
+++ b/src/api/school.js
@@ -105,9 +105,9 @@ export const fetchCategories = async () => {
   return data;
 };
 
-export const scheduleInterView = async (applicantId, body) => {
+export const scheduleInterView = async (applicationId, body) => {
   const data = await apiClient(
-    SCHEDULE_INTERVIEW(applicantId),
+    SCHEDULE_INTERVIEW(applicationId),
     {
       method: "POST",
       body: JSON.stringify(body),
@@ -117,9 +117,9 @@ export const scheduleInterView = async (applicantId, body) => {
   return data;
 };
 
-export const shortListApplicant = async (applicantId, body) => {
+export const shortListApplicant = async (applicationId, body) => {
   const data = await apiClient(
-    APPLICATION_SHORTLIST(applicantId),
+    APPLICATION_SHORTLIST(applicationId),
     {
       method: "PATCH",
       body: JSON.stringify(body),

--- a/src/components/jobApplicants/ApplicantDetails.jsx
+++ b/src/components/jobApplicants/ApplicantDetails.jsx
@@ -28,7 +28,9 @@ const ApplicantDetails = () => {
   const user = JSON.parse(localStorage.getItem("user"));
   const isSchool = user?.role === "school";
   const isStudent = user?.role === "student";
-  const { id } = location.state || {};
+  const searchParams = new URLSearchParams(location.search);
+  const applicationId =
+    location.state?.applicationId || searchParams.get("applicationId");
 
   const [applicant, setApplicant] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -60,14 +62,14 @@ const ApplicantDetails = () => {
   };
 
   const shortList = async () => {
-    if (!id) {
-      toast.error("Missing applicant ID");
+    if (!applicationId) {
+      toast.error("Missing application ID");
       return;
     }
     setLoading(true);
     try {
       const payload = { status: "shortlisted" };
-      const res = await shortListApplicant(id, payload);
+      const res = await shortListApplicant(applicationId, payload);
       res?.success
         ? toast.success("Applicant shortlisted successfully!")
         : toast.error(res?.message || "Shortlisting failed");
@@ -271,7 +273,7 @@ const ApplicantDetails = () => {
       {isSchool && (
         <ScheduleModal
           isOpen={isModalOpen}
-          applicantId={id}
+          applicationId={applicationId}
           onClose={() => setIsModalOpen(false)}
         />
       )}

--- a/src/components/jobApplicants/SchoolApplicantProfile.jsx
+++ b/src/components/jobApplicants/SchoolApplicantProfile.jsx
@@ -244,7 +244,7 @@ const SchoolApplicantProfile = () => {
       <ScheduleModal
         isOpen={showSchedule}
         onClose={() => setShowSchedule(false)}
-        applicantId={applicationId}
+        applicationId={applicationId}
       />
     </div>
   );

--- a/src/components/scheduleInterview/ScheduleModal.jsx
+++ b/src/components/scheduleInterview/ScheduleModal.jsx
@@ -3,7 +3,7 @@ import { formatDate } from "@/utils/helper/formatDate";
 import React, { useState } from "react";
 import { toast } from "react-toastify";
 
-const ScheduleModal = ({ isOpen, onClose, applicantId }) => {
+const ScheduleModal = ({ isOpen, onClose, applicationId }) => {
   const [date, setDate] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
@@ -11,8 +11,8 @@ const ScheduleModal = ({ isOpen, onClose, applicantId }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!applicantId) {
-      toast.error("Applicant ID is missing!");
+    if (!applicationId) {
+      toast.error("Application ID is missing!");
       return;
     }
     const payload = {
@@ -24,7 +24,7 @@ const ScheduleModal = ({ isOpen, onClose, applicantId }) => {
 
     try {
       setLoading(true);
-      const response = await scheduleInterView(applicantId, payload);
+      const response = await scheduleInterView(applicationId, payload);
       if (response?.success) {
         toast.success("Interview scheduled successfully!");
         onClose();

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -30,12 +30,12 @@ export const buildJobsURL = ({
   return `${JOBS_POSTING}?${params.toString()}`;
 };
 
-export const SCHEDULE_INTERVIEW = (applicantId) =>
-  `/school/applications/${applicantId}/schedule`;
+export const SCHEDULE_INTERVIEW = (applicationId) =>
+  `/school/applications/${applicationId}/schedule`;
 export const ONBOARDING = "/auth/complete-onboarding";
 export const USER_PROFILE = "/school/profile";
 
 export const PROFILE_IMAGE_UPLOAD = "/upload/profile-image";
 
-export const APPLICATION_SHORTLIST = (applicantId) =>
-  `/school/applications/${applicantId}/status`;
+export const APPLICATION_SHORTLIST = (applicationId) =>
+  `/school/applications/${applicationId}/status`;


### PR DESCRIPTION
## Summary
- ensure ApplicantDetails fetches application ID from search params or state
- rename schedule modal prop to `applicationId`
- update school API helpers and constants to use application ID
- adjust SchoolApplicantProfile to match new modal prop

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885cdfc30f083318b50f87262c19d6a