### PR TITLE
Add interview details modal for schools

### DIFF
--- a/src/api/school.js
+++ b/src/api/school.js
@@ -11,6 +11,7 @@ import {
   JOBS_API,
   ONBOARDING,
   SCHEDULE_INTERVIEW,
+  APPLICATION_INTERVIEW,
   USER_PROFILE,
   // SCHOOL_PROFILE, // Correctly imported and no longer duplicated
 } from "@/utils/constants";
@@ -111,6 +112,17 @@ export const scheduleInterView = async (applicationId, body) => {
     {
       method: "POST",
       body: JSON.stringify(body),
+    },
+    false
+  );
+  return data;
+};
+
+export const getInterviewDetails = async (applicationId) => {
+  const data = await apiClient(
+    APPLICATION_INTERVIEW(applicationId),
+    {
+      method: "GET",
     },
     false
   );

--- a/src/components/interview/InterviewDetailsModal.jsx
+++ b/src/components/interview/InterviewDetailsModal.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Calendar, Clock, MapPin } from "lucide-react";
+import { format } from "date-fns";
+
+const InterviewDetailsModal = ({ open, onClose, interview }) => {
+  if (!interview) return null;
+  const date = format(new Date(interview.date), "do MMM yyyy");
+  const time = `${interview.startTime} - ${interview.endTime}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-sm text-gray-500">
+            {interview.jobTitle}
+          </DialogTitle>
+          <DialogTitle className="text-lg font-semibold">
+            {interview.applicantName}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 mt-2">
+          <div className="flex items-center gap-2">
+            <Calendar className="w-4 h-4 text-gray-500" />
+            <span>{date}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Clock className="w-4 h-4 text-gray-500" />
+            <span>{time}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <MapPin className="w-4 h-4 text-gray-500" />
+            <span>{interview.location}</span>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default InterviewDetailsModal;

--- a/src/components/scheduleInterview/ScheduleModal.jsx
+++ b/src/components/scheduleInterview/ScheduleModal.jsx
@@ -43,7 +43,7 @@ const ScheduleModal = ({ isOpen, onClose, applicationId, onScheduled }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
@@ -51,27 +51,27 @@ const ScheduleModal = ({ isOpen, onClose, applicationId, onScheduled }) => {
       ></div>
 
       {/* Modal */}
-      <div className="relative bg-white p-6 rounded-xl shadow-lg w-full max-w-md z-50">
-        <h2 className="text-xl font-semibold mb-4">Schedule Interview</h2>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="relative bg-white p-6 rounded-lg shadow-lg w-full max-w-md z-50 space-y-4">
+        <h2 className="text-xl font-semibold">Schedule Interview</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col space-y-4">
           <input
             type="date"
             required
-            className="border p-2 rounded"
+            className="border border-gray-300 p-2 rounded-md"
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
           <input
             type="time"
             required
-            className="border p-2 rounded"
+            className="border border-gray-300 p-2 rounded-md"
             value={startTime}
             onChange={(e) => setStartTime(e.target.value)}
           />
           <input
             type="time"
             required
-            className="border p-2 rounded"
+            className="border border-gray-300 p-2 rounded-md"
             value={endTime}
             onChange={(e) => setEndTime(e.target.value)}
           />

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -32,6 +32,8 @@ export const buildJobsURL = ({
 
 export const SCHEDULE_INTERVIEW = (applicationId) =>
   `/school/applications/${applicationId}/schedule`;
+export const APPLICATION_INTERVIEW = (applicationId) =>
+  `/school/applications/${applicationId}/interview`;
 export const ONBOARDING = "/auth/complete-onboarding";
 export const USER_PROFILE = "/school/profile";
 


### PR DESCRIPTION
## Summary
- add constant for fetching interview data and new API helper
- show interview details in a modal instead of navigating to calendar
- remove reject option from applicant details
- auto-mark applicant as shortlisted when scheduling interview
- enhance schedule modal spacing and rounded corners

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885e4829a7083319826cbbcc876a099